### PR TITLE
Optimize bash startup by reducing expensive subprocess calls

### DIFF
--- a/bash-powerline.sh
+++ b/bash-powerline.sh
@@ -16,6 +16,9 @@ __powerline() {
     readonly SYMBOL_GIT_PUSH='↑'
     readonly SYMBOL_GIT_PULL='↓'
 
+    # Check path-shrinker once at init, not on every prompt
+    __powerline_path_shrinker=$(command -v path-shrinker 2>/dev/null)
+
     if [[ -z "$PS_SYMBOL" ]]; then
       case "$(uname)" in
           Darwin)   PS_SYMBOL='';;
@@ -83,8 +86,7 @@ __powerline() {
         fi
 
         #PS1="\w$git$symbol"
-        __path_shrinker=$(which path-shrinker)
-        if [ "$__path_shrinker" != "" ]; then
+        if [ -n "$__powerline_path_shrinker" ]; then
             __cwd=$(path-shrinker -fish)
         else
             __cwd='\w'


### PR DESCRIPTION
- Hardcode brew --prefix instead of running `brew --prefix` (~200-800ms)
- Lazy-load nvm: defer nvm.sh loading until nvm/node/npm/npx is first used (~200-500ms)
- Cache eval outputs for fzf, rbenv, mise, wtp, direnv using __cached_eval helper
- Move path-shrinker lookup out of per-prompt ps1() into one-time init
- Lazy-load JAVA_HOME to avoid /usr/libexec/java_home on every startup
- Skip duplicate git-completion.bash load when bash_completion.sh already loaded
- Remove duplicate nvm bash_completion loading

https://claude.ai/code/session_01HT2bZTjgwrjrY78DuMdbPh