### PR TITLE
Replace slow brew --prefix call with hardcoded paths

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -68,7 +68,13 @@ alias gpl='git pull --prune'
 
 _bp_log "alias"
 
-BREW_PREFIX_DIR=$(/opt/homebrew/bin/brew --prefix)
+#BREW_PREFIX_DIR=$(/opt/homebrew/bin/brew --prefix)
+# Hardcoded to avoid slow `brew --prefix` call
+if [ -d /opt/homebrew ]; then
+    BREW_PREFIX_DIR=/opt/homebrew
+elif [ -d /usr/local/Homebrew ]; then
+    BREW_PREFIX_DIR=/usr/local
+fi
 BREW_CASKROOM_DIR=$BREW_PREFIX_DIR/Caskroom
 HOMEBREW_NO_AUTO_UPDATE=1
 


### PR DESCRIPTION
## Summary
- Replace `brew --prefix` subprocess call with direct directory checks for `/opt/homebrew` (Apple Silicon) and `/usr/local` (Intel)
- Speeds up `.bash_profile` sourcing by avoiding a slow Homebrew subprocess on every shell startup

## Test plan
- [ ] Open a new terminal on Apple Silicon Mac and verify `BREW_PREFIX_DIR` is set to `/opt/homebrew`
- [ ] Verify Homebrew completions and cask-dependent paths still work correctly

## Check

- before: `[profile]     83 ms (+  51 ms) brew --prefix`
- after: `[profile]     44 ms (+  13 ms) brew --prefix`


🤖 Generated with [Claude Code](https://claude.com/claude-code)