### PR TITLE
Comment out rbenv initialization

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -360,10 +360,10 @@ if [ -d /usr/local/opt/ruby ]; then
 fi
 
 # rbenv
-if [ -f /opt/homebrew/bin/rbenv ]; then
-    __cached_eval "/opt/homebrew/bin/rbenv init - bash"
-    _PATH=$_PATH:$HOME/.rbenv/shims
-fi
+# if [ -f /opt/homebrew/bin/rbenv ]; then
+#     __cached_eval "/opt/homebrew/bin/rbenv init - bash"
+#     _PATH=$_PATH:$HOME/.rbenv/shims
+# fi
 
 _bp_log "rbenv"
 


### PR DESCRIPTION
## Summary
- Comment out rbenv initialization block in `.bash_profile`
- rbenv is no longer needed, removing it to simplify shell startup. Use `mise`

## Test plan
- [ ] Open a new terminal and verify shell starts without errors
- [ ] Confirm Ruby is not needed via rbenv

🤖 Generated with [Claude Code](https://claude.com/claude-code)