### PR TITLE
Add Codex global instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ brew bundle install  # Install Homebrew packages from Brewfile
 - **`.bash_profile`** — Main shell config. Initializes Homebrew, fzf, mise, direnv, Go, GCloud SDK, pnpm, and bash-powerline prompt. Uses `__cached_eval` to cache slow `eval "$(cmd)"` calls for faster startup. Contains custom fzf functions (`fbr`, `fshow`, `fco`, `fco_preview`, `fghpr`). Supports startup profiling via `BASH_PROFILE_PROFILING=1`. Note: rbenv, NVM, and asdf are currently commented out.
 - **`setup.sh`** — Installation script that symlinks dotfiles to `$HOME`.
 - **`claude.sh`** — Symlinks Claude Code configs from `home.claude/` to `~/.claude/`.
+- **`codex.sh`** — Symlinks Codex configs from `home.codex/` to `~/.codex/`.
 - **`Brewfile`** — Homebrew dependencies (formulae, casks, VS Code extensions).
 - **`macos.sh`** — macOS system defaults (Finder, keyboard, Dock preferences).
 - **`.gitconfig`** — Git config with SSH signing via 1Password (`op-ssh-sign`), ghq root at `~/workspace`, and custom aliases (`amend`, `cleanup-branches`, `log-fancy`, etc.).
@@ -29,6 +30,7 @@ brew bundle install  # Install Homebrew packages from Brewfile
 - **`bash-powerline.sh`** — Custom bash prompt with git branch display.
 - **`vscode/`** — VS Code settings, keybindings, and tasks (Go with gopls/gofumpt).
 - **`home.claude/`** — Claude Code configuration (`settings.json`, custom commands in `commands/`).
+- **`home.codex/`** — Codex configuration and global instructions (`AGENTS.md`).
 - **`.github/workflows/`** — GitHub Actions workflows (e.g., `claude.yml`).
 - **`.config/git/ignore`** — Global git ignore patterns.
 - **`go.sh`** — Go tool installation script.
@@ -44,5 +46,6 @@ brew bundle install  # Install Homebrew packages from Brewfile
 - The `bash-it/` directory exists but bash-it is currently disabled in `.bash_profile`.
 - When adding a new dotfile, add it to `setup.sh`'s symlink loop and place it in the repo root.
 - Claude Code configs go in `home.claude/` and are symlinked to `~/.claude/` by `claude.sh`.
+- Codex configs go in `home.codex/` and are symlinked to `~/.codex/` by `codex.sh`.
 - Git commits are signed with SSH keys via 1Password.
 - Use `__cached_eval` in `.bash_profile` for slow `eval "$(cmd)"` calls. It caches command output in `~/.cache/bash_startup/` and invalidates when the binary's mtime changes.

--- a/codex.sh
+++ b/codex.sh
@@ -7,6 +7,10 @@ DOTFILES_DIR="$(cd "$(dirname "$0")" && pwd)"
 mkdir -p ~/.codex
 for entry in "$DOTFILES_DIR"/home.codex/*; do
     name=$(basename "$entry")
+    if [ "$name" = "config.toml" ]; then
+        echo "Skipped $entry"
+        continue
+    fi
     target="$HOME/.codex/$name"
     if [ -e "$target" ] || [ -L "$target" ]; then
         rm -rf "$target"

--- a/codex.sh
+++ b/codex.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+set -eu
+
+DOTFILES_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+mkdir -p ~/.codex
+for entry in "$DOTFILES_DIR"/home.codex/*; do
+    name=$(basename "$entry")
+    target="$HOME/.codex/$name"
+    if [ -e "$target" ] || [ -L "$target" ]; then
+        rm -rf "$target"
+        echo "Removed $target"
+    fi
+    ln -s "$entry" "$target"
+    echo "Linked $target -> $entry"
+done

--- a/home.codex/AGENTS.md
+++ b/home.codex/AGENTS.md
@@ -1,0 +1,8 @@
+# Global Codex Instructions
+
+## Go Commands
+
+- In Codex sandboxed sessions, run Go tests and Go build-related commands with a writable build cache under `/tmp`, because the default Go build cache may be outside the writable sandbox.
+- Prefer `env GOCACHE=/tmp/go-build-cache go test ./...` instead of plain `go test ./...`.
+- For package-scoped tests, keep the same prefix, for example `env GOCACHE=/tmp/go-build-cache go test ./cmd/foo ./internal/bar`.
+- For `golangci-lint`, use `env GOCACHE=/tmp/go-build-cache GOLANGCI_LINT_CACHE=/tmp/golangci-lint-cache go tool golangci-lint run ...`.

--- a/setup.sh
+++ b/setup.sh
@@ -7,15 +7,9 @@ fi
 mkdir -p ~/.config/git
 mkdir -p ~/.config/karabiner
 mkdir -p ~/.config/cmux
-mkdir -p ~/.codex
 for file in .bash* .fzf.* .z* .gitconfig .psqlrc .tmux.conf Brewfile .config/git/ignore .config/karabiner/karabiner.json .config/cmux/cmux.json; do
     rm -i ~/$file
     ln -s $PWD/$file ~/$file
-done
-
-for file in AGENTS.md; do
-    rm -i ~/.codex/$file
-    ln -s $PWD/home.codex/$file ~/.codex/$file
 done
 
 # Workaround for "The operation couldn’t be completed. Unable to locate a Java Runtime."

--- a/setup.sh
+++ b/setup.sh
@@ -7,9 +7,15 @@ fi
 mkdir -p ~/.config/git
 mkdir -p ~/.config/karabiner
 mkdir -p ~/.config/cmux
+mkdir -p ~/.codex
 for file in .bash* .fzf.* .z* .gitconfig .psqlrc .tmux.conf Brewfile .config/git/ignore .config/karabiner/karabiner.json .config/cmux/cmux.json; do
     rm -i ~/$file
     ln -s $PWD/$file ~/$file
+done
+
+for file in AGENTS.md; do
+    rm -i ~/.codex/$file
+    ln -s $PWD/home.codex/$file ~/.codex/$file
 done
 
 # Workaround for "The operation couldn’t be completed. Unable to locate a Java Runtime."


### PR DESCRIPTION
## Summary
- Add home.codex/AGENTS.md with global Codex guidance for Go commands in sandboxed sessions
- Add codex.sh to symlink home.codex into ~/.codex
- Include Codex AGENTS.md linking in setup.sh and document the new files

## Tests

- sh -n codex.sh