### PR TITLE
Add codex-plugins.sh to install Codex plugins

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ brew bundle install  # Install Homebrew packages from Brewfile
 - **`claude.sh`** — Symlinks Claude Code configs from `home.claude/` to `~/.claude/`.
 - **`claude-plugins.sh`** — Installs Claude Code marketplaces and plugins via the `claude` CLI.
 - **`codex.sh`** — Symlinks Codex configs from `home.codex/` to `~/.codex/`.
+- **`codex-plugins.sh`** — Installs Codex plugins (e.g. superpowers) via the `codex` CLI.
 - **`Brewfile`** — Homebrew dependencies (formulae, casks, VS Code extensions).
 - **`macos.sh`** — macOS system defaults (Finder, keyboard, Dock preferences).
 - **`.gitconfig`** — Git config with SSH signing via 1Password (`op-ssh-sign`), ghq root at `~/workspace`, and custom aliases (`amend`, `cleanup-branches`, `log-fancy`, etc.).
@@ -47,6 +48,6 @@ brew bundle install  # Install Homebrew packages from Brewfile
 - The `bash-it/` directory exists but bash-it is currently disabled in `.bash_profile`.
 - When adding a new dotfile, add it to `setup.sh`'s symlink loop and place it in the repo root.
 - Claude Code configs go in `home.claude/` and are symlinked to `~/.claude/` by `claude.sh`. Marketplaces and plugins are installed separately by `claude-plugins.sh`.
-- Codex configs go in `home.codex/` and are symlinked to `~/.codex/` by `codex.sh`.
+- Codex configs go in `home.codex/` and are symlinked to `~/.codex/` by `codex.sh`. Plugins are installed separately by `codex-plugins.sh`.
 - Git commits are signed with SSH keys via 1Password.
 - Use `__cached_eval` in `.bash_profile` for slow `eval "$(cmd)"` calls. It caches command output in `~/.cache/bash_startup/` and invalidates when the binary's mtime changes.

--- a/README.md
+++ b/README.md
@@ -25,3 +25,15 @@ Install Claude Code plugins
 ```
 ./claude-plugins.sh
 ```
+
+## Set up Codex
+
+```
+./codex.sh
+```
+
+Install Codex plugins
+
+```
+./codex-plugins.sh
+```

--- a/codex-plugins.sh
+++ b/codex-plugins.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+set -eu
+
+# Install Codex plugins from configured marketplace snapshots.
+# Marketplaces and the installed-plugin state are managed by codex itself
+# and intentionally not version-controlled.
+if ! command -v codex >/dev/null 2>&1; then
+    echo "codex command not found; skipping plugin installation"
+    exit 0
+fi
+
+plugins="
+superpowers@openai-curated
+"
+existing_plugins=$(codex plugin list 2>/dev/null || true)
+printf '%s\n' "$plugins" | while read -r plugin; do
+    [ -z "$plugin" ] && continue
+    # `codex plugin list` prints one line per plugin, e.g.
+    #   superpowers@openai-curated  installed, enabled  5.1.3  /path/...
+    #   superpowers@openai-curated  not installed              /path/...
+    status_line=$(printf '%s\n' "$existing_plugins" | grep "^$plugin[[:space:]]" || true)
+    if [ -n "$status_line" ] && ! printf '%s\n' "$status_line" | grep -q "not installed"; then
+        echo "Plugin already installed: $plugin"
+    else
+        echo "Installing plugin: $plugin"
+        codex plugin add "$plugin"
+    fi
+done


### PR DESCRIPTION
## Summary

- Add `codex-plugins.sh`, modeled on `claude-plugins.sh`, to install Codex plugins via the `codex` CLI
- Installs the `superpowers@openai-curated` plugin — confirmed to be obra/superpowers v5.1.3, the same suite installed for Claude. It lives in the bundled `openai-curated` marketplace that Codex auto-manages, so no marketplace add is needed.
- Idempotent: checks `codex plugin list` and skips plugins already installed
- Document `codex-plugins.sh` in `AGENTS.md` and add a Codex setup section to `README.md`

## Test plan

- [x] `sh -n codex-plugins.sh` passes syntax check
- [x] Detection logic dry-run: correctly reports `superpowers@openai-curated` as `not installed` → would run `codex plugin add`
- [x] Script is executable

🤖 Generated with [Claude Code](https://claude.com/claude-code)