### PR TITLE
Add cmux helper script

### DIFF
--- a/cmux/blog.sh
+++ b/cmux/blog.sh
@@ -9,7 +9,7 @@ if [ ! -d "$cwd" ]; then
     exit 1
 fi
 
-cmux new-workspace \
+cmux workspace create \
     --name blog \
     --cwd "$cwd" \
     --focus true

--- a/cmux/blog.sh
+++ b/cmux/blog.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -eu
+
+cwd="$HOME/workspace/oinume/blog"
+
+if [ ! -d "$cwd" ]; then
+    echo "Directory not found: $cwd" >&2
+    exit 1
+fi
+
+cmux new-workspace \
+    --name blog \
+    --cwd "$cwd" \
+    --focus true

--- a/cmux/dotfiles.sh
+++ b/cmux/dotfiles.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+set -eu
+
+cwd="$HOME/dotfiles"
+
+if [ ! -d "$cwd" ]; then
+    echo "Directory not found: $cwd" >&2
+    exit 1
+fi
+
+cmux new-workspace \
+    --name dotfiles \
+    --cwd "$cwd" \
+    --layout '{"pane":{"surfaces":[{"type":"terminal"},{"type":"terminal","focus":true}]}}' \
+    --focus true

--- a/cmux/dotfiles.sh
+++ b/cmux/dotfiles.sh
@@ -9,7 +9,7 @@ if [ ! -d "$cwd" ]; then
     exit 1
 fi
 
-cmux new-workspace \
+cmux workspace create \
     --name dotfiles \
     --cwd "$cwd" \
     --layout '{"pane":{"surfaces":[{"type":"terminal"},{"type":"terminal","focus":true}]}}' \


### PR DESCRIPTION
## Summary

- Add `cmux/dotfiles.sh` to open a `dotfiles` workspace in `~/dotfiles` with two terminal tabs
- Add `cmux/blog.sh` to open a `blog` workspace in `~/workspace/oinume/blog` with one terminal tab
- Validate each target directory before creating its workspace
- Focus the newly created workspace

## Test plan

- [x] `sh -n cmux/blog.sh cmux/dotfiles.sh`
- [x] `shellcheck cmux/blog.sh cmux/dotfiles.sh`
- [x] Confirm both scripts are executable