### PR TITLE
[codex] Add install-agent-skills skill

### DIFF
--- a/.agents/skills/install-agent-skill/SKILL.md
+++ b/.agents/skills/install-agent-skill/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: install-agent-skills
+name: install-agent-skill
 description: Install a named skill from a GitHub repository into this dotfiles repository for both Codex and Claude Code. Use when the user provides or wants to provide a repository and skill to install for both agents.
 ---
 
-# Install Agent Skills
+# Install Agent Skill
 
 Install one skill from a GitHub repository into the managed skill directories for both Codex and Claude Code.
 

--- a/.agents/skills/install-agent-skills/SKILL.md
+++ b/.agents/skills/install-agent-skills/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: install-agent-skills
-description: Install a named skill from a GitHub repository for both Codex and Claude Code at user scope. Use when the user provides or wants to provide a repository and skill to install for both agents.
+description: Install a named skill from a GitHub repository into this dotfiles repository for both Codex and Claude Code. Use when the user provides or wants to provide a repository and skill to install for both agents.
 ---
 
 # Install Agent Skills
 
-Install one skill from a GitHub repository for both Codex and Claude Code.
+Install one skill from a GitHub repository into the managed skill directories for both Codex and Claude Code.
 
 ## Inputs
 
@@ -18,14 +18,14 @@ If either value is missing and cannot be inferred from the conversation, ask the
 
 ## Installation
 
-Run these commands separately so each agent receives the skill at user scope:
+Run these commands separately from the dotfiles repository root so each agent receives the skill in its managed directory:
 
 ```bash
-gh skill install <repo> <skill> --agent codex --scope user
-gh skill install <repo> <skill> --agent claude-code --scope user
+gh skill install <repo> <skill> --dir home.codex/skills
+gh skill install <repo> <skill> --dir home.claude/skills
 ```
 
-Replace `<repo>` and `<skill>` with the resolved input values. Preserve a version suffix or exact path when the user supplied one. Do not add `--force`, `--pin`, `--all`, or other options unless the user requests that behavior.
+Replace `<repo>` and `<skill>` with the resolved input values. Preserve a version suffix or exact path when the user supplied one. `--dir` overrides `--agent` and `--scope`, so do not add either of those options. Do not add `--force`, `--pin`, `--all`, or other options unless the user requests that behavior.
 
 If the first command fails, diagnose and report the failure before deciding whether the second command can still run. Never report success for an agent whose command failed.
 

--- a/.agents/skills/install-agent-skills/SKILL.md
+++ b/.agents/skills/install-agent-skills/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: install-agent-skills
+description: Install a named skill from a GitHub repository for both Codex and Claude Code at user scope. Use when the user provides or wants to provide a repository and skill to install for both agents.
+---
+
+# Install Agent Skills
+
+Install one skill from a GitHub repository for both Codex and Claude Code.
+
+## Inputs
+
+Determine these two values from the user's request:
+
+- `repo`: GitHub repository in `OWNER/REPO` format.
+- `skill`: Skill name, namespaced name, exact skill path, or `skill@version` accepted by `gh skill install`.
+
+If either value is missing and cannot be inferred from the conversation, ask the user for it before running any command. Repeat both resolved values before installation when they are ambiguous.
+
+## Installation
+
+Run these commands separately so each agent receives the skill at user scope:
+
+```bash
+gh skill install <repo> <skill> --agent codex --scope user
+gh skill install <repo> <skill> --agent claude-code --scope user
+```
+
+Replace `<repo>` and `<skill>` with the resolved input values. Preserve a version suffix or exact path when the user supplied one. Do not add `--force`, `--pin`, `--all`, or other options unless the user requests that behavior.
+
+If the first command fails, diagnose and report the failure before deciding whether the second command can still run. Never report success for an agent whose command failed.
+
+## Result
+
+Report the installation result for Codex and Claude Code separately, including the installed skill name and repository. Include any action the user must take when `gh` reports an authentication, repository access, or overwrite prompt problem.


### PR DESCRIPTION
## Summary

- add the shared `install-agent-skills` skill under `.agents/skills`
- accept a GitHub repository and skill identifier
- install the selected skill for both Codex and Claude Code at user scope
- report each agent's installation result separately

## Why

This replaces the repeated manual `gh skill install` commands with a reusable agent skill while preserving explicit repository and skill inputs.

## Impact

Agents can install the same skill for Codex and Claude Code consistently without changing project-scoped configuration.

## Validation

- `gh skill install . install-agent-skills --from-local --allow-hidden-dirs --dir <temporary-directory>`
- `git diff --check`

Closes #48
